### PR TITLE
File paths always path rooted

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ These goals might not align to your goals or your organization's goals to which 
 ### From source
 
 1. Download and install [.NET 9](https://dotnet.microsoft.com/download).
-2. Fork the repository using GitHub or clone the repository manually with submodules: `git clone --recurse-submodules https://github.com/bottlenoselabs/SDL3-cs`.
-3. Build the native shared libraries (SDL and SDL extensions) by running [`./ext/build-native-libraries.sh`](./ext/build-native-libraries.sh). To execute `.sh` (Bash) scripts on Windows, use Git Bash which can be installed with Git itself: https://git-scm.com/download/win. The `build-native-libraries.sh` script requires that CMake and SDL build dependencies ([see Linux docs for required packages](https://wiki.libsdl.org/SDL3/README/linux)) are installed and in your environment variable `PATH`.
+2. Clone the repository manually with submodules: `git clone --recurse-submodules https://github.com/bottlenoselabs/SDL3-cs`.
+3. Build the native shared libraries (SDL and SDL extensions) by running [`./ext/build-native-libraries.sh`](./ext/build-native-libraries.sh).
+    - Windows. To execute `.sh` (Bash) scripts on Windows, use Git Bash which can be [installed with Git](https://git-scm.com/download/win). For CMake on Windows, it's recommended to install through [Visual Studio Installer](https://visualstudio.microsoft.com/downloads/) for the workloads "Desktop development with C++" and "Game development with C++". Additionally on Windows, the [NASM assembler](https://www.nasm.us/) is required and to be in your `PATH` environment variable.
+    - macOS. Install XCode through the App Store.
+    - Linux. See [required packages](https://wiki.libsdl.org/SDL3/README/linux).
 4. Run an example suite suite to test things are working. Use '1' and '2' on your keyboard to move between examples in the suite once run.
-   - `SDL_GPU`: `dotnet run --project ./src/cs/examples/SDL_GPU/SDL_GPU.csproj`
-   - `LazyFoo`: `dotnet run --project ./src/cs/examples/LazyFoo/LazyFoo.csproj`
+   - `SDL_GPU`: `dotnet run --project ./src/cs/examples/Examples.Gpu/Examples.Gpu.csproj`
+   - `LazyFoo`: `dotnet run --project ./src/cs/examples/Examples.LazyFoo/Examples.LazyFoo.csproj`
 5. Add the following C# project to your solution and reference it in one of your C# project:
     - `./src/cs/production/SDL/SDL.csproj`
 

--- a/src/cs/production/SDL/GPU/GpuCommandBuffer.cs
+++ b/src/cs/production/SDL/GPU/GpuCommandBuffer.cs
@@ -59,7 +59,7 @@ public sealed unsafe class GpuCommandBuffer : Poolable<GpuCommandBuffer>
     ///     The render-target <see cref="GpuTexture" /> which will be presented to the <paramref name="window" /> when
     ///     <see cref="GpuCommandBuffer.Submit" /> is called.
     /// </param>
-    /// <returns><c>true</c> if the texture was successful acquired; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the texture was successfully acquired; otherwise, <c>false</c>.</returns>
     /// <exception cref="InvalidOperationException">The command buffer is submitted to the device.</exception>
     /// <remarks>
     ///     <para>

--- a/src/cs/production/SDL/IO/FileSystem.cs
+++ b/src/cs/production/SDL/IO/FileSystem.cs
@@ -39,13 +39,17 @@ public sealed unsafe class FileSystem : Disposable
     /// </remarks>
     public bool TryLoadFile(string filePath, out File file)
     {
+        var fullFilePath = GetFullFilePath(filePath);
+
         ulong dataSize;
         _filePathAllocator.Reset();
-        var filePathC = _filePathAllocator.AllocateCString(filePath);
-        var dataPointer = SDL_LoadFile(filePathC, &dataSize);
+        var fullFilePathC = _filePathAllocator.AllocateCString(fullFilePath);
+        var filePointer = SDL_LoadFile(fullFilePathC, &dataSize);
         _filePathAllocator.Reset();
-        if (dataPointer == null)
+        if (filePointer == null)
         {
+            Console.WriteLine(filePath);
+            Console.WriteLine(fullFilePath);
             Error.NativeFunctionFailed(nameof(SDL_LoadFile));
             file = null!;
             return false;
@@ -54,13 +58,13 @@ public sealed unsafe class FileSystem : Disposable
         var file2 = _poolFile.GetOrCreate();
         if (file2 == null)
         {
-            SDL_free(dataPointer);
+            SDL_free(filePointer);
             file = null!;
             return false;
         }
 
         file = file2;
-        file.Set(filePath, (IntPtr)dataPointer, (int)dataSize);
+        file.Set(fullFilePath, (IntPtr)filePointer, (int)dataSize);
         return true;
     }
 
@@ -94,11 +98,13 @@ public sealed unsafe class FileSystem : Disposable
             throw new ArgumentException("Invalid desired pixel format.");
         }
 
+        var fullFilePath = GetFullFilePath(filePath);
+
         _filePathAllocator.Reset();
-        var filePathC = _filePathAllocator.AllocateCString(filePath);
-        var surfaceHandle = SDL_image.IMG_Load(filePathC);
+        var fullFilePathC = _filePathAllocator.AllocateCString(fullFilePath);
+        var surfacePointer = SDL_image.IMG_Load(fullFilePathC);
         _filePathAllocator.Reset();
-        if (surfaceHandle == null)
+        if (surfacePointer == null)
         {
             Error.NativeFunctionFailed(nameof(SDL_image.IMG_Load));
             surface = null;
@@ -106,21 +112,21 @@ public sealed unsafe class FileSystem : Disposable
         }
 
         var desiredPixelFormat2 = (SDL_PixelFormat)(desiredPixelFormat ?? PixelFormat.Unknown);
-        if (desiredPixelFormat != null && surfaceHandle->format != desiredPixelFormat2)
+        if (desiredPixelFormat != null && surfacePointer->format != desiredPixelFormat2)
         {
-            var convertedSurfaceHandle = SDL_ConvertSurface(surfaceHandle, desiredPixelFormat2);
-            if (convertedSurfaceHandle == null)
+            var convertedSurfacePointer = SDL_ConvertSurface(surfacePointer, desiredPixelFormat2);
+            if (convertedSurfacePointer == null)
             {
                 Error.NativeFunctionFailed(nameof(SDL_ConvertSurface));
                 surface = null;
                 return false;
             }
 
-            SDL_DestroySurface(surfaceHandle);
-            surfaceHandle = convertedSurfaceHandle;
+            SDL_DestroySurface(surfacePointer);
+            surfacePointer = convertedSurfacePointer;
         }
 
-        surface = new Surface((IntPtr)surfaceHandle);
+        surface = new Surface((IntPtr)surfacePointer);
         return true;
     }
 
@@ -129,5 +135,16 @@ public sealed unsafe class FileSystem : Disposable
     {
         _poolFile.Dispose();
         _filePathAllocator.Dispose();
+    }
+
+    private static string GetFullFilePath(string filePath)
+    {
+        var fullFilePath = filePath;
+        if (!Path.IsPathRooted(filePath))
+        {
+            fullFilePath = Path.Combine(AppContext.BaseDirectory, filePath);
+        }
+
+        return fullFilePath;
     }
 }

--- a/src/cs/production/SDL/IO/FileSystem.cs
+++ b/src/cs/production/SDL/IO/FileSystem.cs
@@ -24,14 +24,14 @@ public sealed unsafe class FileSystem : Disposable
     }
 
     /// <summary>
-    ///     Attempts to to load a file given a specified file path.
+    ///     Attempts to load a file given a specified file path.
     /// </summary>
     /// <param name="filePath">
     ///     The path to the file. If the path is relative, it is assumed to be relative to
     ///     <see cref="AppContext.BaseDirectory" />.
     /// </param>
     /// <param name="file">The resulting file if successfully loaded; otherwise, <c>null</c>.</param>
-    /// <returns><c>true</c> if the file was successful loaded; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the file was successfully loaded; otherwise, <c>false</c>.</returns>
     /// <remarks>
     ///     <para>
     ///         <see cref="TryLoadFile" /> is not thread safe.
@@ -65,7 +65,7 @@ public sealed unsafe class FileSystem : Disposable
     }
 
     /// <summary>
-    ///     Attempts to load a file given the a specified file path as an image.
+    ///     Attempts to load a file as an image given the specified file path.
     /// </summary>
     /// <param name="filePath">
     ///     The path to the file. If the path is relative, it is assumed to be relative to
@@ -77,7 +77,7 @@ public sealed unsafe class FileSystem : Disposable
     ///     image will attempt to be converted to this pixel format. Use <c>null</c> to disable conversion and have the
     ///     image in the same pixel format as the file format.
     /// </param>
-    /// <returns><c>true</c> if the image was successful loaded; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the image was successfully loaded; otherwise, <c>false</c>.</returns>
     /// <exception cref="ArgumentException">Invalid <paramref name="desiredPixelFormat" />.</exception>
     /// <remarks>
     ///     <para>


### PR DESCRIPTION
- Fixes #635 running the GPU examples on command line on Windows by ensuring file paths are always path rooted.