### PR TITLE
Add `Application` callback to receive raw `SDL_Event`.

### DIFF
--- a/src/cs/production/SDL/Application.cs
+++ b/src/cs/production/SDL/Application.cs
@@ -172,6 +172,14 @@ public abstract unsafe partial class Application : Disposable
     protected abstract void OnKeyUp(in KeyboardEvent e);
 
     /// <summary>
+    ///     Called when an event is received from SDL.
+    /// </summary>
+    /// <param name="e">The event.</param>
+    protected virtual void OnEvent(in SDL_Event e)
+    {
+    }
+
+    /// <summary>
     ///     Called when the application determines it is time to update a frame. This is where your application would
     ///     update its state.
     /// </summary>
@@ -288,6 +296,8 @@ public abstract unsafe partial class Application : Disposable
                 break;
             }
         }
+
+        OnEvent(e);
     }
 
     private void HandleMouseMotionEvent(in SDL_MouseMotionEvent mouseMotionEvent)


### PR DESCRIPTION
This is useful when integrating with external libraries that have SDL backend (e.g. ImGui). Those libraries sometimes expect to receive an `SDL_Event*` in order to update their internal state.

Without this callback, the user is required to either construct a matching `SDL_Event` themselves or use whatever alternative API the library might provide to update the internal state manually, which just adds a lot of unnecessary work.